### PR TITLE
some suggested changes

### DIFF
--- a/Code/GraphMol/FileParsers/CMLWriter.cpp
+++ b/Code/GraphMol/FileParsers/CMLWriter.cpp
@@ -28,20 +28,7 @@
 #endif
 
 namespace RDKit {
-
 namespace {
-double determinant(double a00, double a01, double a10, double a11) noexcept {
-  return a00 * a11 - a01 * a10;
-}
-
-double determinant(double a00, double a01, double a02,  //
-                   double a10, double a11, double a12,  //
-                   double a20, double a21, double a22) noexcept {
-  return a00 * determinant(a11, a12, a21, a22) -
-         a01 * determinant(a10, a12, a20, a22) +
-         a02 * determinant(a10, a11, a20, a21);
-}
-
 boost::property_tree::ptree molToPTree(const ROMol& mol, int confId,
                                        bool kekulize) {
   RWMol rwmol{mol};
@@ -51,12 +38,12 @@ boost::property_tree::ptree molToPTree(const ROMol& mol, int confId,
 
   boost::property_tree::ptree pt;
   // prefix namespaces
-  auto& root = pt.add("cml:cml", "");
-  root.put("<xmlattr>.xmlns:cml", "http://www.xml-cml.org/schema");
+  auto& root = pt.add("cml", "");
+  root.put("<xmlattr>.xmlns", "http://www.xml-cml.org/schema");
   root.put("<xmlattr>.xmlns:convention", "http://www.xml-cml.org/convention/");
   root.put("<xmlattr>.convention", "convention:molecular");
 
-  auto& molecule = root.add("cml:molecule", "");
+  auto& molecule = root.add("molecule", "");
 
   // molecule/@id MUST start with an alphabetical character
   // http://www.xml-cml.org/convention/molecular#molecule-id
@@ -67,7 +54,7 @@ boost::property_tree::ptree molToPTree(const ROMol& mol, int confId,
   std::string name;
   rwmol.getPropIfPresent(common_properties::_Name, name);
   if (!name.empty()) {
-    molecule.put("cml:name", name);
+    molecule.put("name", name);
   }
 
   int mol_formal_charge = 0;
@@ -77,9 +64,9 @@ boost::property_tree::ptree molToPTree(const ROMol& mol, int confId,
   // http://www.xml-cml.org/convention/molecular#atom-id
   const auto atom_id_prefix = "a";
 
-  auto& atomArray = molecule.put("cml:atomArray", "");
+  auto& atomArray = molecule.put("atomArray", "");
   for (unsigned i = 0u, nAtoms = rwmol.getNumAtoms(); i < nAtoms; i++) {
-    auto& atom = atomArray.add("cml:atom", "");
+    auto& atom = atomArray.add("atom", "");
     const auto& a = rwmol.getAtomWithIdx(i);
 
     atom.put("<xmlattr>.id", boost::format{"%1%%2%"} % atom_id_prefix % i);
@@ -93,7 +80,7 @@ boost::property_tree::ptree molToPTree(const ROMol& mol, int confId,
     mol_formal_charge += charge;
     atom.put("<xmlattr>.formalCharge", charge);
 
-    atom.put("<xmlattr>.hydrogenCount", a->getTotalNumHs());
+    atom.put("<xmlattr>.hydrogenCount", a->getTotalNumHs(true));
 
     const auto isotope = a->getIsotope();
     if (isotope) {
@@ -114,59 +101,39 @@ boost::property_tree::ptree molToPTree(const ROMol& mol, int confId,
     if (!conf.is3D()) {
       atom.put("<xmlattr>.x2", xyz_fmt % pos.x);
       atom.put("<xmlattr>.y2", xyz_fmt % pos.y);
-      continue;
+    } else {
+      atom.put("<xmlattr>.x3", xyz_fmt % pos.x);
+      atom.put("<xmlattr>.y3", xyz_fmt % pos.y);
+      atom.put("<xmlattr>.z3", xyz_fmt % pos.z);
     }
-
-    atom.put("<xmlattr>.x3", xyz_fmt % pos.x);
-    atom.put("<xmlattr>.y3", xyz_fmt % pos.y);
-    atom.put("<xmlattr>.z3", xyz_fmt % pos.z);
-
     // atom/@atomParity if chiral
     // http://www.xml-cml.org/convention/molecular#atom-atomParity
-    const auto chiral = a->getChiralTag();
-    if (chiral == Atom::CHI_UNSPECIFIED || chiral == Atom::CHI_OTHER) {
-      continue;
+    // the parity is the sign of the chiral volume. We can determine that from
+    // the ChiralTag:
+    int parity = 0;
+    switch (a->getChiralTag()) {
+      case Atom::CHI_TETRAHEDRAL_CCW:
+        parity = 1;
+        break;
+      case Atom::CHI_TETRAHEDRAL_CW:
+        parity = -1;
+        break;
+      default:
+        parity = 0;
     }
+    if (parity) {
+      std::vector<unsigned> neighbors;
+      for (auto nbri : boost::make_iterator_range(mol.getAtomNeighbors(a))) {
+        const auto at = mol[nbri];
+        neighbors.push_back(at->getIdx());
+      }
 
-    std::vector<RDGeom::Point3D> xyzs;
-    std::vector<unsigned> neighbors;
-    for (auto nbri : boost::make_iterator_range(mol.getAtomBonds(a))) {
-      const auto* const b = mol[nbri];
-      const auto o = b->getOtherAtom(a)->getIdx();
-      neighbors.push_back(o);
-      xyzs.push_back(conf.getAtomPos(o));
+      auto& atomParity = atom.add("atomParity", parity);
+      atomParity.put("<xmlattr>.atomRefs4",
+                     boost::format{"%1%%2% %1%%3% %1%%4% %1%%5%"} %
+                         atom_id_prefix % neighbors[0u] % neighbors[1u] %
+                         neighbors[2u] % neighbors[3u]);
     }
-
-    if (neighbors.size() != 4u) {
-      continue;
-    }
-
-    /* atomParity = sign(det([[1,  1,  1,  1],
-                              [x0, x1, x2, x3],
-                              [y0, y1, y2, y3],
-                              [z0, z1, z2, z3]]))
-     */
-    const auto det = determinant(xyzs[1u].x, xyzs[2u].x, xyzs[3u].x,  //
-                                 xyzs[1u].y, xyzs[2u].y, xyzs[3u].y,  //
-                                 xyzs[1u].z, xyzs[2u].z, xyzs[3u].z) -
-                     determinant(xyzs[0u].x, xyzs[2u].x, xyzs[3u].x,  //
-                                 xyzs[0u].y, xyzs[2u].y, xyzs[3u].y,  //
-                                 xyzs[0u].z, xyzs[2u].z, xyzs[3u].z) +
-                     determinant(xyzs[0u].x, xyzs[1u].x, xyzs[3u].x,  //
-                                 xyzs[0u].y, xyzs[1u].y, xyzs[3u].y,  //
-                                 xyzs[0u].z, xyzs[1u].z, xyzs[3u].z) -
-                     determinant(xyzs[0u].x, xyzs[1u].x, xyzs[2u].x,  //
-                                 xyzs[0u].y, xyzs[1u].y, xyzs[2u].y,  //
-                                 xyzs[0u].z, xyzs[1u].z, xyzs[2u].z);
-    if (det == 0.0) {
-      continue;
-    }
-
-    auto& atomParity = atom.add("cml:atomParity", det > 0.0 ? 1 : -1);
-    atomParity.put("<xmlattr>.atomRefs4",
-                   boost::format{"%1%%2% %1%%3% %1%%4% %1%%5%"} %
-                       atom_id_prefix % neighbors[0u] % neighbors[1u] %
-                       neighbors[2u] % neighbors[3u]);
   }
 
   molecule.put("<xmlattr>.formalCharge", mol_formal_charge);
@@ -184,7 +151,7 @@ boost::property_tree::ptree molToPTree(const ROMol& mol, int confId,
   const auto bond_id_prefix = "b";
   unsigned bond_id = 0u;
 
-  auto& bondArray = molecule.add("cml:bondArray", "");
+  auto& bondArray = molecule.add("bondArray", "");
   for (auto atom_itr = rwmol.beginAtoms(), atom_itr_end = rwmol.endAtoms();
        atom_itr != atom_itr_end; ++atom_itr) {
     const auto& atom = *atom_itr;
@@ -201,7 +168,7 @@ boost::property_tree::ptree molToPTree(const ROMol& mol, int confId,
         continue;
       }
 
-      auto& bond = bondArray.add("cml:bond", "");
+      auto& bond = bondArray.add("bond", "");
       bond.put("<xmlattr>.atomRefs2",
                boost::format{"%1%%2% %1%%3%"} % atom_id_prefix % src % dst);
 

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -1408,7 +1408,7 @@ TEST_CASE("CML writer", "[CML][writer]") {
       <bond atomRefs2="a0 a2" id="b1" order="S"/>
       <bond atomRefs2="a0 a3" id="b2" order="S"/>
       <bond atomRefs2="a0 a4" id="b3" order="S"/>
-      <bond atomRefs2="a4 a5" id="b4" order="S"/>
+      <bond atomRefs2="a4 a5" id="b4" order="S" bondStereo="H"/>
       <bond atomRefs2="a4 a6" id="b5" order="S"/>
       <bond atomRefs2="a4 a8" id="b6" order="S"/>
       <bond atomRefs2="a6 a7" id="b7" order="S"/>
@@ -1462,7 +1462,7 @@ M  END
     <bondArray>
       <bond atomRefs2="a0 a1" id="b0" order="S"/>
       <bond atomRefs2="a1 a2" id="b1" order="S"/>
-      <bond atomRefs2="a1 a3" id="b2" order="S"/>
+      <bond atomRefs2="a1 a3" id="b2" order="S" bondStereo="W"/>
       <bond atomRefs2="a1 a4" id="b3" order="S"/>
     </bondArray>
   </molecule>
@@ -1507,6 +1507,35 @@ M  END
       <atom id="a2" elementType="Br" formalCharge="0" hydrogenCount="0" x2="0.891800" y2="2.032800"/>
       <atom id="a3" elementType="F" formalCharge="0" hydrogenCount="0" x2="2.431800" y2="0.492800"/>
       <atom id="a4" elementType="Cl" formalCharge="0" hydrogenCount="0" x2="-0.648200" y2="0.492800"/>
+    </atomArray>
+    <bondArray>
+      <bond atomRefs2="a0 a1" id="b0" order="S"/>
+      <bond atomRefs2="a1 a2" id="b1" order="S"/>
+      <bond atomRefs2="a1 a3" id="b2" order="S" bondStereo="H"/>
+      <bond atomRefs2="a1 a4" id="b3" order="S"/>
+    </bondArray>
+  </molecule>
+</cml>
+)CML";
+    CHECK(cmlblock == cmlblock_expected);
+  }
+
+  SECTION("no conformer") {
+    auto mol = "C[C@](O)(F)Cl"_smiles;
+    REQUIRE(mol);
+    const std::string cmlblock = MolToCMLBlock(*mol);
+    const std::string cmlblock_expected =
+        R"CML(<?xml version="1.0" encoding="utf-8"?>
+<cml xmlns="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
+  <molecule id="m-1" formalCharge="0" spinMultiplicity="1">
+    <atomArray>
+      <atom id="a0" elementType="C" formalCharge="0" hydrogenCount="3"/>
+      <atom id="a1" elementType="C" formalCharge="0" hydrogenCount="0">
+        <atomParity atomRefs4="a0 a2 a3 a4">1</atomParity>
+      </atom>
+      <atom id="a2" elementType="O" formalCharge="0" hydrogenCount="1"/>
+      <atom id="a3" elementType="F" formalCharge="0" hydrogenCount="0"/>
+      <atom id="a4" elementType="Cl" formalCharge="0" hydrogenCount="0"/>
     </atomArray>
     <bondArray>
       <bond atomRefs2="a0 a1" id="b0" order="S"/>

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -1348,13 +1348,8 @@ TEST_CASE("CML writer", "[CML][writer]") {
       auto *a = new Atom{z};
       mol->addAtom(a, false, true);
     }
-    mol->getAtomWithIdx(0u)->setNumExplicitHs(3u);
-    mol->getAtomWithIdx(4u)->setNumExplicitHs(1u);
-    mol->getAtomWithIdx(6u)->setNumExplicitHs(1u);
     mol->getAtomWithIdx(7u)->setIsotope(2u);
     mol->getAtomWithIdx(10u)->setFormalCharge(-1);
-
-    mol->getAtomWithIdx(4u)->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW);
 
     mol->addBond(0u, 1u, Bond::SINGLE);
     mol->addBond(0u, 2u, Bond::SINGLE);
@@ -1384,41 +1379,143 @@ TEST_CASE("CML writer", "[CML][writer]") {
 
     mol->addConformer(conf);
 
+    mol->updatePropertyCache();
+    MolOps::assignChiralTypesFrom3D(*mol);
+
     const std::string cmlblock = MolToCMLBlock(*mol);
     const std::string cmlblock_expected =
         R"CML(<?xml version="1.0" encoding="utf-8"?>
-<cml:cml xmlns:cml="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
-  <cml:molecule id="m-1" formalCharge="-1" spinMultiplicity="1">
-    <cml:name>S-lactic acid</cml:name>
-    <cml:atomArray>
-      <cml:atom id="a0" elementType="C" formalCharge="0" hydrogenCount="3" x3="-0.953300" y3="0.604160" z3="1.016090"/>
-      <cml:atom id="a1" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.008320" y3="1.687460" z3="0.835200"/>
-      <cml:atom id="a2" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.962740" y3="0.161030" z3="0.944710"/>
-      <cml:atom id="a3" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.577010" y3="0.447370" z3="2.041670"/>
-      <cml:atom id="a4" elementType="C" formalCharge="0" hydrogenCount="1" x3="0.000000" y3="0.000000" z3="0.000000">
-        <cml:atomParity atomRefs4="a0 a5 a6 a8">-1</cml:atomParity>
-      </cml:atom>
-      <cml:atom id="a5" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.430380" y3="0.185960" z3="-1.013770"/>
-      <cml:atom id="a6" elementType="O" formalCharge="0" hydrogenCount="1" x3="0.225380" y3="-1.365310" z3="0.193730"/>
-      <cml:atom id="a7" elementType="H" formalCharge="0" hydrogenCount="0" isotopeNumber="2" x3="1.219930" y3="-1.339370" z3="0.145800"/>
-      <cml:atom id="a8" elementType="C" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="0.730030" z3="0.000000"/>
-      <cml:atom id="a9" elementType="O" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="1.967950" z3="0.000000"/>
-      <cml:atom id="a10" elementType="O" formalCharge="-1" hydrogenCount="0" x3="2.352530" y3="-0.077000" z3="0.000000"/>
-    </cml:atomArray>
-    <cml:bondArray>
-      <cml:bond atomRefs2="a0 a1" id="b0" order="S"/>
-      <cml:bond atomRefs2="a0 a2" id="b1" order="S"/>
-      <cml:bond atomRefs2="a0 a3" id="b2" order="S"/>
-      <cml:bond atomRefs2="a0 a4" id="b3" order="S"/>
-      <cml:bond atomRefs2="a4 a5" id="b4" order="S"/>
-      <cml:bond atomRefs2="a4 a6" id="b5" order="S"/>
-      <cml:bond atomRefs2="a4 a8" id="b6" order="S"/>
-      <cml:bond atomRefs2="a6 a7" id="b7" order="S"/>
-      <cml:bond atomRefs2="a8 a9" id="b8" order="D"/>
-      <cml:bond atomRefs2="a8 a10" id="b9" order="S"/>
-    </cml:bondArray>
-  </cml:molecule>
-</cml:cml>
+<cml xmlns="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
+  <molecule id="m-1" formalCharge="-1" spinMultiplicity="1">
+    <name>S-lactic acid</name>
+    <atomArray>
+      <atom id="a0" elementType="C" formalCharge="0" hydrogenCount="3" x3="-0.953300" y3="0.604160" z3="1.016090"/>
+      <atom id="a1" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.008320" y3="1.687460" z3="0.835200"/>
+      <atom id="a2" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.962740" y3="0.161030" z3="0.944710"/>
+      <atom id="a3" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.577010" y3="0.447370" z3="2.041670"/>
+      <atom id="a4" elementType="C" formalCharge="0" hydrogenCount="1" x3="0.000000" y3="0.000000" z3="0.000000">
+        <atomParity atomRefs4="a0 a5 a6 a8">1</atomParity>
+      </atom>
+      <atom id="a5" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.430380" y3="0.185960" z3="-1.013770"/>
+      <atom id="a6" elementType="O" formalCharge="0" hydrogenCount="1" x3="0.225380" y3="-1.365310" z3="0.193730"/>
+      <atom id="a7" elementType="H" formalCharge="0" hydrogenCount="0" isotopeNumber="2" x3="1.219930" y3="-1.339370" z3="0.145800"/>
+      <atom id="a8" elementType="C" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="0.730030" z3="0.000000"/>
+      <atom id="a9" elementType="O" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="1.967950" z3="0.000000"/>
+      <atom id="a10" elementType="O" formalCharge="-1" hydrogenCount="0" x3="2.352530" y3="-0.077000" z3="0.000000"/>
+    </atomArray>
+    <bondArray>
+      <bond atomRefs2="a0 a1" id="b0" order="S"/>
+      <bond atomRefs2="a0 a2" id="b1" order="S"/>
+      <bond atomRefs2="a0 a3" id="b2" order="S"/>
+      <bond atomRefs2="a0 a4" id="b3" order="S"/>
+      <bond atomRefs2="a4 a5" id="b4" order="S"/>
+      <bond atomRefs2="a4 a6" id="b5" order="S"/>
+      <bond atomRefs2="a4 a8" id="b6" order="S"/>
+      <bond atomRefs2="a6 a7" id="b7" order="S"/>
+      <bond atomRefs2="a8 a9" id="b8" order="D"/>
+      <bond atomRefs2="a8 a10" id="b9" order="S"/>
+    </bondArray>
+  </molecule>
+</cml>
+)CML";
+    CHECK(cmlblock == cmlblock_expected);
+  }
+
+  SECTION("chirality1") {
+    auto mol = R"CTAB(
+  Mrv1921 04232106262D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 1
+M  V30 BEGIN ATOM
+M  V30 1 I 0.8918 -1.0472 0 0
+M  V30 2 C 0.8918 0.4928 0 0
+M  V30 3 Br 0.8918 2.0328 0 0
+M  V30 4 F 2.4318 0.4928 0 0
+M  V30 5 Cl -0.6482 0.4928 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1
+M  V30 2 1 2 3 CFG=3
+M  V30 3 1 2 4 CFG=1
+M  V30 4 1 2 5
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    const std::string cmlblock = MolToCMLBlock(*mol);
+    const std::string cmlblock_expected =
+        R"CML(<?xml version="1.0" encoding="utf-8"?>
+<cml xmlns="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
+  <molecule id="m-1" formalCharge="0" spinMultiplicity="1">
+    <atomArray>
+      <atom id="a0" elementType="I" formalCharge="0" hydrogenCount="0" x2="0.891800" y2="-1.047200"/>
+      <atom id="a1" elementType="C" formalCharge="0" hydrogenCount="0" x2="0.891800" y2="0.492800">
+        <atomParity atomRefs4="a0 a2 a3 a4">1</atomParity>
+      </atom>
+      <atom id="a2" elementType="Br" formalCharge="0" hydrogenCount="0" x2="0.891800" y2="2.032800"/>
+      <atom id="a3" elementType="F" formalCharge="0" hydrogenCount="0" x2="2.431800" y2="0.492800"/>
+      <atom id="a4" elementType="Cl" formalCharge="0" hydrogenCount="0" x2="-0.648200" y2="0.492800"/>
+    </atomArray>
+    <bondArray>
+      <bond atomRefs2="a0 a1" id="b0" order="S"/>
+      <bond atomRefs2="a1 a2" id="b1" order="S"/>
+      <bond atomRefs2="a1 a3" id="b2" order="S"/>
+      <bond atomRefs2="a1 a4" id="b3" order="S"/>
+    </bondArray>
+  </molecule>
+</cml>
+)CML";
+    CHECK(cmlblock == cmlblock_expected);
+  }
+  SECTION("chirality2") {
+    auto mol = R"CTAB(
+  Mrv1921 04232106262D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 1
+M  V30 BEGIN ATOM
+M  V30 1 I 0.8918 -1.0472 0 0
+M  V30 2 C 0.8918 0.4928 0 0
+M  V30 3 Br 0.8918 2.0328 0 0
+M  V30 4 F 2.4318 0.4928 0 0
+M  V30 5 Cl -0.6482 0.4928 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1
+M  V30 2 1 2 3 CFG=1
+M  V30 3 1 2 4 CFG=3
+M  V30 4 1 2 5
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    const std::string cmlblock = MolToCMLBlock(*mol);
+    const std::string cmlblock_expected =
+        R"CML(<?xml version="1.0" encoding="utf-8"?>
+<cml xmlns="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
+  <molecule id="m-1" formalCharge="0" spinMultiplicity="1">
+    <atomArray>
+      <atom id="a0" elementType="I" formalCharge="0" hydrogenCount="0" x2="0.891800" y2="-1.047200"/>
+      <atom id="a1" elementType="C" formalCharge="0" hydrogenCount="0" x2="0.891800" y2="0.492800">
+        <atomParity atomRefs4="a0 a2 a3 a4">-1</atomParity>
+      </atom>
+      <atom id="a2" elementType="Br" formalCharge="0" hydrogenCount="0" x2="0.891800" y2="2.032800"/>
+      <atom id="a3" elementType="F" formalCharge="0" hydrogenCount="0" x2="2.431800" y2="0.492800"/>
+      <atom id="a4" elementType="Cl" formalCharge="0" hydrogenCount="0" x2="-0.648200" y2="0.492800"/>
+    </atomArray>
+    <bondArray>
+      <bond atomRefs2="a0 a1" id="b0" order="S"/>
+      <bond atomRefs2="a1 a2" id="b1" order="S"/>
+      <bond atomRefs2="a1 a3" id="b2" order="S"/>
+      <bond atomRefs2="a1 a4" id="b3" order="S"/>
+    </bondArray>
+  </molecule>
+</cml>
 )CML";
     CHECK(cmlblock == cmlblock_expected);
   }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5636,47 +5636,44 @@ M  END
     mol.SetProp('_Name', 'S-lactic acid')
     mol.AddConformer(conf)
 
-    mol.GetAtomWithIdx(0).SetNumExplicitHs(3)
-    mol.GetAtomWithIdx(4).SetNumExplicitHs(1)
-    mol.GetAtomWithIdx(6).SetNumExplicitHs(1)
     mol.GetAtomWithIdx(7).SetIsotope(2)
     mol.GetAtomWithIdx(10).SetFormalCharge(-1)
 
     mol.GetAtomWithIdx(4).SetChiralTag(Chem.ChiralType.CHI_TETRAHEDRAL_CCW)
 
     cmlblock_expected = """<?xml version="1.0" encoding="utf-8"?>
-<cml:cml xmlns:cml="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
-  <cml:molecule id="m-1" formalCharge="-1" spinMultiplicity="1">
-    <cml:name>S-lactic acid</cml:name>
-    <cml:atomArray>
-      <cml:atom id="a0" elementType="C" formalCharge="0" hydrogenCount="3" x3="-0.953300" y3="0.604160" z3="1.016090"/>
-      <cml:atom id="a1" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.008320" y3="1.687460" z3="0.835200"/>
-      <cml:atom id="a2" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.962740" y3="0.161030" z3="0.944710"/>
-      <cml:atom id="a3" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.577010" y3="0.447370" z3="2.041670"/>
-      <cml:atom id="a4" elementType="C" formalCharge="0" hydrogenCount="1" x3="0.000000" y3="0.000000" z3="0.000000">
-        <cml:atomParity atomRefs4="a0 a5 a6 a8">-1</cml:atomParity>
-      </cml:atom>
-      <cml:atom id="a5" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.430380" y3="0.185960" z3="-1.013770"/>
-      <cml:atom id="a6" elementType="O" formalCharge="0" hydrogenCount="1" x3="0.225380" y3="-1.365310" z3="0.193730"/>
-      <cml:atom id="a7" elementType="H" formalCharge="0" hydrogenCount="0" isotopeNumber="2" x3="1.219930" y3="-1.339370" z3="0.145800"/>
-      <cml:atom id="a8" elementType="C" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="0.730030" z3="0.000000"/>
-      <cml:atom id="a9" elementType="O" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="1.967950" z3="0.000000"/>
-      <cml:atom id="a10" elementType="O" formalCharge="-1" hydrogenCount="0" x3="2.352530" y3="-0.077000" z3="0.000000"/>
-    </cml:atomArray>
-    <cml:bondArray>
-      <cml:bond atomRefs2="a0 a1" id="b0" order="S"/>
-      <cml:bond atomRefs2="a0 a2" id="b1" order="S"/>
-      <cml:bond atomRefs2="a0 a3" id="b2" order="S"/>
-      <cml:bond atomRefs2="a0 a4" id="b3" order="S"/>
-      <cml:bond atomRefs2="a4 a5" id="b4" order="S"/>
-      <cml:bond atomRefs2="a4 a6" id="b5" order="S"/>
-      <cml:bond atomRefs2="a4 a8" id="b6" order="S"/>
-      <cml:bond atomRefs2="a6 a7" id="b7" order="S"/>
-      <cml:bond atomRefs2="a8 a9" id="b8" order="D"/>
-      <cml:bond atomRefs2="a8 a10" id="b9" order="S"/>
-    </cml:bondArray>
-  </cml:molecule>
-</cml:cml>
+<cml xmlns="http://www.xml-cml.org/schema" xmlns:convention="http://www.xml-cml.org/convention/" convention="convention:molecular">
+  <molecule id="m-1" formalCharge="-1" spinMultiplicity="1">
+    <name>S-lactic acid</name>
+    <atomArray>
+      <atom id="a0" elementType="C" formalCharge="0" hydrogenCount="3" x3="-0.953300" y3="0.604160" z3="1.016090"/>
+      <atom id="a1" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.008320" y3="1.687460" z3="0.835200"/>
+      <atom id="a2" elementType="H" formalCharge="0" hydrogenCount="0" x3="-1.962740" y3="0.161030" z3="0.944710"/>
+      <atom id="a3" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.577010" y3="0.447370" z3="2.041670"/>
+      <atom id="a4" elementType="C" formalCharge="0" hydrogenCount="1" x3="0.000000" y3="0.000000" z3="0.000000">
+        <atomParity atomRefs4="a0 a5 a6 a8">1</atomParity>
+      </atom>
+      <atom id="a5" elementType="H" formalCharge="0" hydrogenCount="0" x3="-0.430380" y3="0.185960" z3="-1.013770"/>
+      <atom id="a6" elementType="O" formalCharge="0" hydrogenCount="1" x3="0.225380" y3="-1.365310" z3="0.193730"/>
+      <atom id="a7" elementType="H" formalCharge="0" hydrogenCount="0" isotopeNumber="2" x3="1.219930" y3="-1.339370" z3="0.145800"/>
+      <atom id="a8" elementType="C" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="0.730030" z3="0.000000"/>
+      <atom id="a9" elementType="O" formalCharge="0" hydrogenCount="0" x3="1.384900" y3="1.967950" z3="0.000000"/>
+      <atom id="a10" elementType="O" formalCharge="-1" hydrogenCount="0" x3="2.352530" y3="-0.077000" z3="0.000000"/>
+    </atomArray>
+    <bondArray>
+      <bond atomRefs2="a0 a1" id="b0" order="S"/>
+      <bond atomRefs2="a0 a2" id="b1" order="S"/>
+      <bond atomRefs2="a0 a3" id="b2" order="S"/>
+      <bond atomRefs2="a0 a4" id="b3" order="S"/>
+      <bond atomRefs2="a4 a5" id="b4" order="S" bondStereo="H"/>
+      <bond atomRefs2="a4 a6" id="b5" order="S"/>
+      <bond atomRefs2="a4 a8" id="b6" order="S"/>
+      <bond atomRefs2="a6 a7" id="b7" order="S"/>
+      <bond atomRefs2="a8 a9" id="b8" order="D"/>
+      <bond atomRefs2="a8 a10" id="b9" order="S"/>
+    </bondArray>
+  </molecule>
+</cml>
 """
 
     self.assertEqual(Chem.MolToCMLBlock(mol), cmlblock_expected)
@@ -6502,9 +6499,8 @@ CAS<~>
     rwmol = Chem.RWMol(m)
     rwmol.InsertMol(m2)
     rwmol.InsertMol(m3)
-    self.assertEqual(Chem.MolToSmiles(rwmol),
-                     Chem.CanonSmiles("CNO.c1ccccc1.C1CC1"))
-    
+    self.assertEqual(Chem.MolToSmiles(rwmol), Chem.CanonSmiles("CNO.c1ccccc1.C1CC1"))
+
   def testBatchEdits(self):
     mol = Chem.MolFromSmiles("C1CCCO1")
 
@@ -6550,6 +6546,7 @@ CAS<~>
     except:
       pass
     self.assertEqual(rwmol.GetNumAtoms(), mol.GetNumAtoms())
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:


### PR DESCRIPTION
I've made a number of changes here
    
1. stop writing the cml: namespace to the output. Tools like marvin can't read that and it's not nececssary
2. fix the H count
3. continue writing atom info for 2D confs
4. simplify the writing of atom parity
5. make the conformer optional
6. write bond hash/wedge information if there is a conformer

I'm not a super expert on CML, so I may have some of this wrong.
Please take a look and see if you agree with them